### PR TITLE
Limit Maximum MDAnalysis Version to `<2.1`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}
             ${{ runner.os }}
-      - name: "Install/Upgrade setuptools, wheel and python-dev-tools"
+      - name: "Install/Upgrade setuptools and wheel"
+        # MDAnalysis requires NumPy (>=1.19.2) for setup (see also
+        # https://github.com/MDAnalysis/mdanalysis/issues/3374#issuecomment-889189979).
+        # MDAnalysis <3.0 requires Cython <3.0 (see
+        # https://github.com/MDAnalysis/mdanalysis/pull/4129 and
+        # https://github.com/cython/cython/issues/3690).
         # Without `python-dev-tools` the installation of MDAnalysis
         # fails on MacOS-latest with Python 3.9 while building the wheel
         # for MDAnalysis.  Strangely, the MDAnalysis wheel is only build
@@ -77,9 +82,11 @@ jobs:
         run: |
           python -m pip install --user --upgrade setuptools wheel
           python -m pip install --user --upgrade python-dev-tools
+          python -m pip install --user "Cython <3.0"
+          python -m pip install --user "numpy >=1.19.2"
       - name: "Test installation of this project"
         run: |
-          python -m pip install --user --upgrade .
+          python -m pip install --user .
           # The install only installs the required dependencies.  This
           # project contains no python module that can be imported.
           # python -c "import transfer_Li"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
 requires-python = ">=3.7, <3.10"
 dependencies = [
     "mdtools @ git+https://github.com/andthum/mdtools@main",
-    "MDAnalysis >=2.0, <3.0",
+    "MDAnalysis >=2.0, <2.1",
     "numpy >=1.15, <2.0",
 ]
 


### PR DESCRIPTION
# Limit Maximum MDAnalysis Version to `<2.1`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/transfer_Li/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [x] Dependency update.
* [ ] Documentation update.
* [x] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Decrease the maximum allowed MDAnalysis version from `<3.0` to `<2.1`, because higher MDAnalysis versions cause issues during the compilation with Cython on Python 3.7.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/transfer_Li/blob/main/CONTRIBUTING.rst).
* [~] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
